### PR TITLE
[Fix] Obsolete key

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
           universe.ReSeed(-0.005f, 0.01f, 10.0f, 10.0f, 20.0f, 50.0f, 0.01f, false);
         } else if (keycode == sf::Keyboard::W) {
           universe.ToggleWrap();
-        } else if (keycode == sf::Keyboard::Enter) {
+        } else if (keycode == sf::Keyboard::Return) {
           universe.SetRandomParticles();
         } else if (keycode == sf::Keyboard::Tab) {
           universe.PrintParams();


### PR DESCRIPTION
sf::Keyboard::Enter is marked as obsolete key and do not build on some SFML version.
For example Ubuntu LTS 18.04 sfml package does not provide this key.